### PR TITLE
fix alan-turing-institute/reprosyn#63 unexpected keyword arguments

### DIFF
--- a/src/reprosyn/methods/gans/pate_gan.py
+++ b/src/reprosyn/methods/gans/pate_gan.py
@@ -47,6 +47,7 @@ class PateGan(GenerativeModel):
         batch_size=128,
         learning_rate=1e-4,
         multiprocess=False,
+        **kw,
     ):
         """
         :param metadata: dict: Attribute metadata describing the data domain of the synthetic target data


### PR DESCRIPTION
Add catch-all keyword argument to PateGan (see https://github.com/alan-turing-institute/reprosyn/issues/63#issuecomment-1387164997) to allow click to pass its context as keyword arguments.